### PR TITLE
Update README with GPU VRAM settings note

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
 | **HY-Motion-1.0-Lite** | Lightweight Text2Motion Model | 2025-12-30 | 0.46B | [Download](https://huggingface.co/tencent/HY-Motion-1.0/tree/main/HY-Motion-1.0-Lite) | 24GB |
 
 *Note*: To reduce GPU VRAM requirements, please use the following settings: `--num_seeds=1`, text prompt with less than 30 words, and motion length less than 5 seconds.  
+*Note*: This table does not includes GPU VRAM requirements for LLM-based prompt engineering feature. If you have sufficient VRAM to run HY-Motion-1.0 model but gradio fails with a VRAM-related error, Run the Gradio application with prompt engineering disabled by setting the environment variable like this: `DISABLE_PROMPT_ENGINEERING=True python3 gradio_app.py`
 
 ## 🤗 Get Started with HY-Motion 1.0
 


### PR DESCRIPTION
I've tried to run `gradio_app.py` because README.md states RTX5090 is capable of running those models. But when I tried to run `gradio_app.py` for first time - the script failed to run wtih VRAM error.

It was very confusing when I faced this issue for the first time. But after looking around the code and I found the `gradio_app.py` runs prompt engineering feature by default with Qwen 30B A3B model.

I've managed to run `gradio_app.py`without prompt engineering feature - but this is not stated in README.md. For those who will face the same problem I suggest leaving some extra note about VRAM requirement around VRAM requirement table in `README.md`