### PR TITLE
fix: replace bare except clauses with except Exception

### DIFF
--- a/hymotion/prompt_engineering/prompt_rewrite.py
+++ b/hymotion/prompt_engineering/prompt_rewrite.py
@@ -312,7 +312,7 @@ class PromptRewriter:
                 json_str = re.search(r"\{.*\}", response, re.DOTALL).group()
                 result = json.loads(json_str)
                 return round(float(result["duration"]) / 30.0, 2), result["short_caption"]
-            except:
+            except Exception:
                 return 5.0, text
 
 

--- a/hymotion/utils/path.py
+++ b/hymotion/utils/path.py
@@ -160,9 +160,9 @@ def parse_dirs_and_sort(
                         natural_keys(text, retoken=r"[0-9a-zA-Z]*_(\d+)[a-zA-Z_]*[\.].*", n=1),
                     ),
                 )
-            except:
+            except Exception:
                 input_dirs_list = sorted(input_dirs_list, key=lambda text: (natural_keys(text)))
-        except:
+        except Exception:
             input_dirs_list = sorted(input_dirs_list, key=lambda text: text)
 
     return input_dirs_list

--- a/ssae/gemini_video_ssae.py
+++ b/ssae/gemini_video_ssae.py
@@ -131,7 +131,7 @@ class GeminiVideoAnalyzer:
                         line = line.strip()
                         if line:
                             file_items.append(json.loads(line))
-                except:
+                except Exception:
                     # JSON format: the entire file is a JSON array
                     f.seek(0)
                     data = json.load(f)
@@ -235,7 +235,7 @@ class GeminiVideoAnalyzer:
                 for line in f:
                     try:
                         processed_idxs.add(json.loads(line).get("idx"))
-                    except:
+                    except Exception:
                         continue
         # check if the idx has been processed
         items_to_run = [it for it in tqdm(all_items) if it.get("idx") not in processed_idxs]


### PR DESCRIPTION
Replace 5 bare `except:` across 3 files with `except Exception:` to avoid catching `SystemExit`/`KeyboardInterrupt`.